### PR TITLE
(#4) Fix SHA-1 clone mapping in DigestFactory.

### DIFF
--- a/core/src/main/java/org/bouncycastle/crypto/util/DigestFactory.java
+++ b/core/src/main/java/org/bouncycastle/crypto/util/DigestFactory.java
@@ -40,7 +40,7 @@ public final class DigestFactory
         {
             public Digest createClone(Digest original)
             {
-                return new MD5Digest((MD5Digest)original);
+                return new SHA1Digest((SHA1Digest)original);
             }
         });
         cloneMap.put(createSHA224().getAlgorithmName(), new Cloner()


### PR DESCRIPTION
## Fix SHA-1 clone mapping from MD5Digest to SHA1Digest.

This pull request addresses [Issue #4](https://github.com/bcgit/bc-lts-java/issues/4), where the SHA-1 entry in the `DigestFactory.cloneMap` was incorrectly mapped to `MD5Digest`.